### PR TITLE
package.json の情報を更新する

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,21 +1,21 @@
 {
-  "name": "api_pillreq-me",
+  "name": "leadyou",
   "version": "1.0.0",
   "private": "true",
-  "description": "This code is for pull req me project",
-  "main": "server.js",
+  "description": "LEADYOU is a web application that helps you to write a README easily.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/KASHIHARAAkira/api_pillreq-me.git"
+    "url": "git+https://github.com/Hacknock/readme-generator-master.git"
   },
-  "keywords": [
-    "Github"
-  ],
   "author": "Akira Kashihara, Takuto Nakamura",
   "bugs": {
-    "url": "https://github.com/KASHIHARAAkira/api_pillreq-me/issues"
+    "url": "https://github.com/Hacknock/readme-generator-master/issues"
   },
-  "homepage": "https://github.com/KASHIHARAAkira/api_pillreq-me#readme",
+  "homepage": "https://github.com/Hacknock/readme-generator-master#readme",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
   "dependencies": {
     "config": "^3.3.6",
     "express": "^4.17.1",


### PR DESCRIPTION
resolve #262 

リポジトリ名が readme-generator-master から leadyou に変わったら url とか homepage とかも変えないといけない。
Docker 対応したら scriptsのところを修正する。

```json
"scripts": {
  "build": "docker-compose build",
  "up": "docker-compose up -d",
  "down": "docker-compose down",
}
```