### PR TITLE
AutoFillでのバッジの複数読み込みが壊れていたのを修正

### DIFF
--- a/app/public/plugins/custom-elements/wrap-multiline-field.js
+++ b/app/public/plugins/custom-elements/wrap-multiline-field.js
@@ -216,7 +216,7 @@ class WrapMultiField extends HTMLElement {
   }
 
   autoFill(values) {
-    const inputEles = this.shadowRoot.querySelectorAll(".column");
+    let inputEles = this.shadowRoot.querySelectorAll(".column");
     const addButton = this.shadowRoot.getElementById("add-button");
     for (const [i, v] of values.entries()) {
       if (inputEles.length > i) {

--- a/app/public/plugins/custom-elements/wrap-oneline-field.js
+++ b/app/public/plugins/custom-elements/wrap-oneline-field.js
@@ -214,7 +214,7 @@ class WrapOnelineField extends HTMLElement {
   }
 
   autoFill(values) {
-    const inputEles = this.shadowRoot.querySelectorAll(".column");
+    let inputEles = this.shadowRoot.querySelectorAll(".column");
     const addButton = this.shadowRoot.getElementById("add-button");
     for (const [i, v] of values.entries()) {
       if (inputEles.length > i) {


### PR DESCRIPTION
autoFillは再帰関数でinputEles自身を書き換える